### PR TITLE
Add random practice generator with audio playback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,22 @@
 # Guitar Practicer
 
-This app selects a random practice drill for you, based on some selections.
-
+This app selects a random practice drill for you based on a few musical variables.
 
 ## Variables
 
 * Chord root
 * Chord quality (Major, Minor, Augmented, Diminished)
 * Chord augment (none, 2, 4, 7)
-* Position (0-14)
-* Voice (1-3)
-* Technique
-  * Strum
-  * Pluck
-  * Arpeggiate
-  * Tap
+* Position (0–14)
+* Voice (1–3)
+* Technique (Strum, Pluck, Arpeggiate, Tap)
 * Tempo
+
+## Usage
+
+Run `npm run dev` and open the app in your browser. Click **Generate Practice** to generate a random drill. The chosen settings are displayed and the root note is played four times at the selected tempo.
 
 ## Output
 
 Plays the chord root at the tempo.
+

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,34 +1,115 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import { useRef, useState } from 'react'
 import './App.css'
 
+type Practice = {
+  root: string
+  quality: string
+  augment: string
+  position: number
+  voice: number
+  technique: string
+  tempo: number
+}
+
+const roots = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'] as const
+const qualities = ['Major', 'Minor', 'Augmented', 'Diminished'] as const
+const augments = ['None', '2', '4', '7'] as const
+const techniques = ['Strum', 'Pluck', 'Arpeggiate', 'Tap'] as const
+const positions = Array.from({ length: 15 }, (_, i) => i)
+const voices = [1, 2, 3]
+
+const frequencies: Record<(typeof roots)[number], number> = {
+  C: 261.63,
+  'C#': 277.18,
+  D: 293.66,
+  'D#': 311.13,
+  E: 329.63,
+  F: 349.23,
+  'F#': 369.99,
+  G: 392,
+  'G#': 415.3,
+  A: 440,
+  'A#': 466.16,
+  B: 493.88,
+}
+
+function randomItem<T>(arr: readonly T[]): T {
+  return arr[Math.floor(Math.random() * arr.length)]
+}
+
+function generatePractice(): Practice {
+  return {
+    root: randomItem(roots),
+    quality: randomItem(qualities),
+    augment: randomItem(augments),
+    position: randomItem(positions),
+    voice: randomItem(voices),
+    technique: randomItem(techniques),
+    tempo: Math.floor(Math.random() * 80) + 60,
+  }
+}
+
 function App() {
-  const [count, setCount] = useState(0)
+  const [practice, setPractice] = useState<Practice | null>(null)
+  const audioCtx = useRef<AudioContext>()
+
+  const playRoot = (root: string, tempo: number) => {
+    if (!audioCtx.current) {
+      audioCtx.current = new AudioContext()
+    }
+    const ctx = audioCtx.current
+    if (!ctx) return
+    const freq = frequencies[root as keyof typeof frequencies]
+    const interval = 60000 / tempo
+    let count = 0
+
+    const play = () => {
+      const osc = ctx.createOscillator()
+      const gain = ctx.createGain()
+      osc.type = 'sine'
+      osc.frequency.value = freq
+      osc.connect(gain)
+      gain.connect(ctx.destination)
+      osc.start()
+      osc.stop(ctx.currentTime + 0.2)
+    }
+
+    play()
+    const handle = setInterval(() => {
+      count += 1
+      if (count >= 4) {
+        clearInterval(handle)
+        return
+      }
+      play()
+    }, interval)
+  }
+
+  const handleGenerate = () => {
+    const p = generatePractice()
+    setPractice(p)
+    playRoot(p.root, p.tempo)
+  }
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+    <div>
+      <h1>Guitar Practicer</h1>
+      <button onClick={handleGenerate}>Generate Practice</button>
+      {practice && (
+        <div className="card">
+          <h2>Practice Drill</h2>
+          <ul>
+            <li>Root: {practice.root}</li>
+            <li>Quality: {practice.quality}</li>
+            <li>Augment: {practice.augment}</li>
+            <li>Position: {practice.position}</li>
+            <li>Voice: {practice.voice}</li>
+            <li>Technique: {practice.technique}</li>
+            <li>Tempo: {practice.tempo} BPM</li>
+          </ul>
+        </div>
+      )}
+    </div>
   )
 }
 


### PR DESCRIPTION
## Summary
- generate random practice element per README variables
- auto play the chord root note at the generated tempo
- document usage in README

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_686c62c639348327a9265109ffb3a455